### PR TITLE
Add PHP 8.0 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
 install:
   - composer update
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-dist: trusty
 php:
   - '7.1'
   - '7.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-distro: focal
+distro: bionic
 php:
   - '7.1'
   - '7.2'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+distro: focal
 php:
   - '7.1'
   - '7.2'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.1||^8.0",
-        "divineomega/password_exposed": "^3.0.1",
+        "divineomega/password_exposed": "^3.2.0",
         "illuminate/contracts": "^5.1||^6.0||^7.0||^8.0"
     },
     "license": "LGPL-3.0-only",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel validation rule that checks if a password has been exposed in a data breach",
     "type": "library",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1||^8.0",
         "divineomega/password_exposed": "^3.0.1",
         "illuminate/contracts": "^5.1||^6.0||^7.0||^8.0"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,6 @@
     <testsuites>
         <testsuite name="Unit Tests">
             <directory suffix="Test.php">./tests/Unit</directory>
-            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
- Allow PHP 8.0.
- Update password_exposed to ensure PHP 8.0 is allowed there.
- Remove a reference to a nonexistent directory in test config; blocked tests.
- Update distro reference as Trusty doesn't support 8.0.